### PR TITLE
🎨⚡️ Make the Scrip dataclass a NamedTuple.

### DIFF
--- a/numWorkshop.py
+++ b/numWorkshop.py
@@ -1,7 +1,6 @@
 
-from dataclasses import dataclass
 import requests
-from typing import Dict, NoReturn
+from typing import Dict, NamedTuple, NoReturn
 
 from bs4 import BeautifulSoup
 
@@ -15,9 +14,8 @@ class WorkshopError(Exception):
         return self.error
 
 
-@dataclass
-class Script:
-    """Class for numworks workshop python script."""
+class Script(NamedTuple):
+    """Encapsulate a numworks workshop python script."""
     name: str
     description: str
     content: str


### PR DESCRIPTION
No changes will be necessary in the code. This type change will add the ability to iterate over a `Script` object.

For instance:
```py
>>> script = Script("foobar.py", "A test.", 'print("hello world")', True)
>>> for attr in script:
...     attr
... 
'foobar.py'
'A test.'
'print("hello world")'
True
```
Attributes can always be assessed with the dot operator:
```py
>>> script.public
True
```
Script objects will also be indexable:
```py
>>> script[1]
'A test.'
```
```py
>>> name, description, content, public = script
>>> name
'foobar.py'
```
or:
```py
>>> _, content, *_ = script
>>> content
'A test.'
```

**Other advantages**
* Deletion of `dataclasses` module import.